### PR TITLE
TASK1: Add rock-paper-scissors game

### DIFF
--- a/01_git/scissors/Makefile
+++ b/01_git/scissors/Makefile
@@ -1,0 +1,18 @@
+CC=gcc
+CFLAGS=-I.
+CRYPTOLAGS=-lcrypto
+OUT_NAME=rock-paper-scissors
+
+all: $(OUT_NAME)
+
+$(OUT_NAME): rock_paper_scissors.o main.o
+	$(CC) rock_paper_scissors.o main.o -o $(OUT_NAME) $(CFLAGS) $(CRYPTOLAGS)
+
+main.o: main.c
+	$(CC) -c main.c $(CFLAGS)
+
+rock_paper_scissors.o: rock_paper_scissors.c
+	$(CC) -c rock_paper_scissors.c $(CFLAGS)
+
+clean:
+	/bin/rm -rf *.o a.out $(OUT_NAME)

--- a/01_git/scissors/main.c
+++ b/01_git/scissors/main.c
@@ -1,0 +1,7 @@
+#include <rock_paper_scissors.h>
+
+int main()
+{
+    RPS_run_game();
+    return 0;
+}

--- a/01_git/scissors/rock_paper_scissors.c
+++ b/01_git/scissors/rock_paper_scissors.c
@@ -1,0 +1,161 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <openssl/md5.h>
+
+#include "rock_paper_scissors.h"
+
+static RPS_CHOICES_E get_human_choice(void);
+static RPS_CHOICES_E get_random_choice(void);
+static void RPS_show_game_result(RPS_CHOICES_E comp_choice, RPS_CHOICES_E human_choice);
+static void RPS_print_md5(char value);
+
+static RPS_CHOICE_ENTRY_S choices_arr[] = {{RPS_CHOICE_ROCK, "rock", 'r'},
+                                           {RPS_CHOICE_PAPER, "paper", 'p'},
+                                           {RPS_CHOICE_SCISSORS, "scissors", 's'},
+                                           {RPS_CHOICE_UNKNOWN, "unknown", 'u'}};
+
+static RPS_CHOICES_E RPS_get_random_choice(void)
+{
+    unsigned char buff;
+    RPS_CHOICES_E choice = RPS_CHOICE_UNKNOWN;
+
+    int fd = open("/dev/urandom", O_RDONLY);
+
+    if (!fd)
+    {
+        printf("Error opening /dev/urandom\n");
+        exit(1);
+    }
+
+    read(fd, &buff, sizeof buff);
+    close(fd);
+    choice = buff % RPS_N_VALUABLE_CHOICES;
+
+    return choice;
+}
+
+
+static RPS_CHOICES_E RPS_get_human_choice(void)
+{
+    RPS_CHOICES_E choice = RPS_CHOICE_UNKNOWN;
+    char read_value = '?';
+
+    printf("Please choose: rock (r) - paper (p) - scissors (s)\n");
+    scanf(" %c", &read_value);
+
+    switch (read_value)
+    {
+        case 'r':
+            {
+                choice = RPS_CHOICE_ROCK;
+                break;
+            }
+
+        case 'p':
+            {
+                choice = RPS_CHOICE_PAPER;
+                break;
+            }
+        case 's':
+            {
+                choice = RPS_CHOICE_SCISSORS;
+                break;
+            }
+        default:
+            {
+                choice = RPS_CHOICE_UNKNOWN;
+                break;
+            }
+    }
+
+    return choice;
+}
+
+
+static void RPS_print_md5(char value)
+{
+    MD5_CTX ctx;
+    unsigned char md5digest[MD5_DIGEST_LENGTH];
+
+    MD5_Init(&ctx);
+    MD5_Update(&ctx, (const void *)&value, sizeof value);
+    MD5_Final(md5digest, &ctx);
+
+    printf("Random choice: %c md5: ", value);
+
+    for ( int i=0;i < MD5_DIGEST_LENGTH; i++ ) {
+        printf("%02x", md5digest[i]);
+    };
+    printf("\n");
+}
+
+
+static void RPS_show_game_result(RPS_CHOICES_E comp_choice, RPS_CHOICES_E human_choice)
+{
+    RPS_CHOICE_ENTRY_S *p_human_entry;
+    RPS_CHOICE_ENTRY_S *p_comp_entry;
+    int game_result;
+
+    p_comp_entry = &choices_arr[comp_choice];
+    p_human_entry = &choices_arr[human_choice];
+
+    printf("You choose %s, I choose %s\n", p_human_entry->long_name, p_comp_entry->long_name);
+
+    game_result = comp_choice - human_choice;
+
+    switch (game_result)
+    {
+        case 0:
+            {
+                printf("Draw: %s and %s\n", p_human_entry->long_name, p_comp_entry->long_name);
+                break;
+            }
+
+        case 1:
+            {
+                printf("I win: %s beats %s\n", p_comp_entry->long_name, p_human_entry->long_name);
+                break;
+            }
+        case 2:
+            {
+                printf("You win: %s beats %s\n", p_human_entry->long_name, p_comp_entry->long_name);
+                break;
+            }
+        case -1:
+            {
+                printf("You win: %s beats %s\n", p_human_entry->long_name, p_comp_entry->long_name);
+                break;
+            }
+        case -2:
+            {
+                printf("I win: %s beats %s\n", p_comp_entry->long_name, p_human_entry->long_name);
+                break;
+            }
+        default:
+            {
+                printf("Error game result: %i\n", game_result);
+                exit(1);
+                break;
+            }
+    }
+}
+
+
+void RPS_run_game(void)
+{
+    RPS_CHOICES_E human_choice = RPS_CHOICE_UNKNOWN;
+    RPS_CHOICES_E comp_choice = RPS_CHOICE_UNKNOWN;
+
+    comp_choice = RPS_get_random_choice();
+    // Optional task: add printing md5 checksum of computer's choice before human's move.
+    RPS_print_md5(choices_arr[comp_choice].short_name);
+
+    for ( ; human_choice == RPS_CHOICE_UNKNOWN; )
+    {
+        human_choice = RPS_get_human_choice();
+    }
+
+    RPS_show_game_result(comp_choice, human_choice);
+}

--- a/01_git/scissors/rock_paper_scissors.h
+++ b/01_git/scissors/rock_paper_scissors.h
@@ -1,0 +1,23 @@
+#ifndef __ROCK_PAPER_SCISSORS_H_
+#define __ROCK_PAPER_SCISSORS_H_
+
+#define RPS_N_VALUABLE_CHOICES 3
+
+typedef enum RPS_CHOICES {
+    RPS_CHOICE_ROCK,
+    RPS_CHOICE_PAPER,
+    RPS_CHOICE_SCISSORS,
+    RPS_CHOICE_UNKNOWN
+} RPS_CHOICES_E;
+
+
+typedef struct RPS_CHOICE_ENTRY {
+    RPS_CHOICES_E id;
+    char long_name[16];
+    char short_name;
+} RPS_CHOICE_ENTRY_S;
+
+
+void RPS_run_game(void);
+
+#endif // __ROCK_PAPER_SCISSORS_H_


### PR DESCRIPTION
The game logic is defined in "rock_paper_scissors" module.
Additional task printing md5 checksum of computer's choice before human's move is added.

$ make clean all && ./rock-paper-scissors
/bin/rm -rf *.o a.out rock-paper-scissors
gcc -c rock_paper_scissors.c -I.
gcc -c main.c -I.
gcc rock_paper_scissors.o main.o -o rock-paper-scissors -I. -lcrypto
Random choice: s md5: 03c7c0ace395d80182db07ae2c30f034
Please choose: rock (r) - paper (p) - scissors (s)
r
You choose rock, I choose scissors
You win: rock beats scissors

Signed-off-by: Ivan Stepanenko <istepanenko@gmail.com>