### PR TITLE
TASK02 Add hot plugged hardware detector script

### DIFF
--- a/02_bash/hwdetect/hwdetect.sh
+++ b/02_bash/hwdetect/hwdetect.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+FOLDER=${1:-/dev}
+echo "Polling folder: $FOLDER"
+
+PREV=$(stat --terse --format="%n %z" ${FOLDER}/*|sort -n)
+
+while true
+do
+    NEW=$(stat --terse --format="%n %z" ${FOLDER}/*|sort -n)
+    DELTA=$(diff <(echo "$PREV") <(echo "$NEW") | grep '^>')
+
+    if [[ "${#DELTA}" != 0 ]]
+    then
+        echo "$DELTA"
+    fi
+    PREV=$NEW
+    sleep 1
+done


### PR DESCRIPTION
It uses optional script arugment to define polling folder with default value "/dev".
The script is polling that folder and uses "diff" utility to detect changes
in the output. Here is the script run with current target folder and new
1, 2 files playing role of new devices.

$ ./hwdetect.sh .
Polling folder: .
> ./1 2021-11-21 22:25:33.907655100 +0200
> ./2 2021-11-21 22:25:40.335717754 +0200

Signed-off-by: Ivan Stepanenko <istepanenko@gmail.com>