### PR TITLE
TASK5: timediff Kernel module and user space program to get absolute time in different ways

### DIFF
--- a/04_basic_struct/README.md
+++ b/04_basic_struct/README.md
@@ -1,0 +1,7 @@
+## Basic structure homework
+Implement object with name “MyObject” which is parent of kernel_kobj.    
+Object should include linked_list structure.    
+This object should contain sysfs attribute with name “list”.    
+On read form attribute “list” it should show content of the objects linked list.    
+On write to attribute “list” it should add new string to the objects linked list.    
+!! Do not forget properly free all the resources during rmmod.    

--- a/05_timers/README.md
+++ b/05_timers/README.md
@@ -1,0 +1,10 @@
+## Homework: Linux Kernel Time Management
+
+1. Implement program which return absolute time in user space.
+Use clock_gettime() from time.h. Try different clock id.
+Find the difference. Show possible clock resolution provided by clock_getres().
+
+2. Implement kernel module with API in sysfs, which returns relative
+time in maximum possible resolution passed since previous read of it.
+Implement kernel module with API in sysfs which returns absolute time
+of previous reading with maximum resolution like ‘400.123567’ seconds.

--- a/05_timers/timediff/Makefile
+++ b/05_timers/timediff/Makefile
@@ -1,0 +1,11 @@
+KERNELDIR ?= ../../../buildroot/output/build/linux-5.15/ #WARNING relative path
+
+obj-m := timediff.o
+CFLAGS_timediff.o := -DDEBUG
+
+all:
+	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules
+
+clean:
+	$(MAKE) -C $(KERNELDIR) M=$(PWD) clean
+

--- a/05_timers/timediff/dmesg_timediff_absolute.txt
+++ b/05_timers/timediff/dmesg_timediff_absolute.txt
@@ -1,0 +1,8 @@
+[TIMEDIFF] You have not read time_absolute yet
+[TIMEDIFF] Last read was at 809.551044 seconds after system start
+[TIMEDIFF] Last read was at 811.555076 seconds after system start
+[TIMEDIFF] Last read was at 812.950683 seconds after system start
+[TIMEDIFF] Last read was at 813.1678972 seconds after system start
+[TIMEDIFF] Last read was at 814.2792612 seconds after system start
+[TIMEDIFF] Last read was at 818.713325 seconds after system start
+[TIMEDIFF] Last read was at 826.7950020 seconds after system start

--- a/05_timers/timediff/dmesg_timediff_rel.txt
+++ b/05_timers/timediff/dmesg_timediff_rel.txt
@@ -1,0 +1,8 @@
+timediff: loading out-of-tree module taints kernel.
+[TIMEDIFF] You have not read time_relative yet
+[TIMEDIFF] Seconds past since last read: 1.156
+[TIMEDIFF] Seconds past since last read: 2.338
+[TIMEDIFF] Seconds past since last read: 0.896
+[TIMEDIFF] Seconds past since last read: 0.442
+[TIMEDIFF] Seconds past since last read: 10.431
+[TIMEDIFF] Seconds past since last read: 13.789

--- a/05_timers/timediff/timediff.c
+++ b/05_timers/timediff/timediff.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0
 /**
  * @file timediff.c
  * @brief Timediff kernel module.
@@ -18,10 +19,10 @@
 #include <asm-generic/bug.h>
 
 static ssize_t timediff_relative_show(struct kobject *kobj, struct kobj_attribute *attr,
-    char *buf);
+	char *buf);
 
 static ssize_t timediff_absolute_show(struct kobject *kobj, struct kobj_attribute *attr,
-    char *buf);
+	char *buf);
 
 static struct kobject *kobj;
 static struct kobj_attribute  kattr_rel      = __ATTR(time_relative, 0440, timediff_relative_show, NULL);
@@ -31,91 +32,83 @@ static ktime_t last_rel_ktime;
 static struct timespec64 last_abs_ktime;
 
 static ssize_t timediff_relative_show(struct kobject *kobj, struct kobj_attribute *attr,
-    char *buf)
+	char *buf)
 {
-    ktime_t ktime_rel;
-    ktime_t ktime_diff;
-    struct timespec64 ktime_rel_show;
-    int ret;
+	ktime_t ktime_rel;
+	ktime_t ktime_diff;
+	struct timespec64 ktime_rel_show;
+	int ret;
 
-    // CLOCK_MONOTONIC
-    ktime_rel  = ktime_get();
+	// CLOCK_MONOTONIC
+	ktime_rel  = ktime_get();
 
-    if (last_rel_ktime == 0)
-    {
-        ret = sprintf(buf, "You have not read time_relative yet\n");    
-    }
-    else
-    {
-        ktime_diff     = ktime_sub(ktime_rel, last_rel_ktime);
-        ktime_rel_show = ktime_to_timespec64(ktime_diff);
+	if (last_rel_ktime == 0) {
+		ret = sprintf(buf, "You have not read time_relative yet\n");
+	} else {
+		ktime_diff     = ktime_sub(ktime_rel, last_rel_ktime);
+		ktime_rel_show = ktime_to_timespec64(ktime_diff);
 
-        ret = sprintf(buf, "Seconds past since last read: %lld.%ld\n",
-            ktime_rel_show.tv_sec, ktime_rel_show.tv_nsec / 1000000);
-    }
+		ret = sprintf(buf, "Seconds past since last read: %lld.%ld\n",
+			ktime_rel_show.tv_sec, ktime_rel_show.tv_nsec / 1000000);
+	}
 
-    last_rel_ktime = ktime_rel;
+	last_rel_ktime = ktime_rel;
 
-    pr_debug("[TIMEDIFF] %s", buf);
+	pr_debug("[TIMEDIFF] %s", buf);
 
-    return ret;
+	return ret;
 }
 
 static ssize_t timediff_absolute_show(struct kobject *kobj, struct kobj_attribute *attr,
-    char *buf)
+	char *buf)
 {
-    int ret;
+	int ret;
 
-    if (last_abs_ktime.tv_sec == 0)
-    {
-        ret = sprintf(buf, "You have not read time_absolute yet\n");
-    }
-    else
-    {
-        ret = sprintf(buf, "Last read was at %lld.%ld seconds after system start\n",
-            last_abs_ktime.tv_sec, last_abs_ktime.tv_nsec / 100);
-    }
-    
-    pr_debug("[TIMEDIFF] %s", buf);
+	if (last_abs_ktime.tv_sec == 0) {
+		ret = sprintf(buf, "You have not read time_absolute yet\n");
+	} else {
+		ret = sprintf(buf, "Last read was at %lld.%ld seconds after system start\n",
+			last_abs_ktime.tv_sec, last_abs_ktime.tv_nsec / 100);
+	}
 
-    // CLOCK_MONOTONIC
-    ktime_get_ts64(&last_abs_ktime);
+	pr_debug("[TIMEDIFF] %s", buf);
 
-    return ret;
+	// CLOCK_MONOTONIC
+	ktime_get_ts64(&last_abs_ktime);
+
+	return ret;
 }
 
 static int timediff_init(void)
 {
-    int res;
+	int res;
 
-    kobj = kobject_create_and_add("timediff", kernel_kobj);
-    if (kobj == NULL)
-        return -ENOMEM;
+	kobj = kobject_create_and_add("timediff", kernel_kobj);
+	if (kobj == NULL)
+		return -ENOMEM;
 
-    res = sysfs_create_file(kobj, &kattr_rel.attr);
-    if (res)
-    {
-        BUG();
-        pr_err("[TIMEDIFF] Failed to create sysfs file");
-        kobject_put(kobj);
-        return res;
-    }
+	res = sysfs_create_file(kobj, &kattr_rel.attr);
+	if (res) {
+		BUG();
+		pr_err("[TIMEDIFF] Failed to create sysfs file");
+		kobject_put(kobj);
+		return res;
+	}
 
-    res = sysfs_create_file(kobj, &kattr_absolute.attr);
-    if (res)
-    {
-        BUG();
-        pr_err("[TIMEDIFF] Failed to create sysfs file");
-        kobject_put(kobj);
-        return res;
-    }
+	res = sysfs_create_file(kobj, &kattr_absolute.attr);
+	if (res) {
+		BUG();
+		pr_err("[TIMEDIFF] Failed to create sysfs file");
+		kobject_put(kobj);
+		return res;
+	}
 
-    return res;
+	return res;
 }
 
 static void timediff_exit(void)
 {
-    kobject_put(kobj);
+	kobject_put(kobj);
 }
 
 module_init(timediff_init);

--- a/05_timers/timediff/timediff.c
+++ b/05_timers/timediff/timediff.c
@@ -1,0 +1,153 @@
+/**
+ * @file string_storage.c
+ * @brief String Storage kernel module.
+ *   This module allows you to store and retrieve stored strings through sysfs
+ *   file in /sys/kernel/string_storage/list.
+ *   Type echo "some string" > /sys/kernel/string_storage/list to save the string,
+ *   type cat /sys/kernel/string_storage/list to print all the saved strings.
+ */
+
+#include <linux/module.h>
+#include <linux/moduleparam.h>
+#include <linux/kernel.h>
+#include <linux/init.h>
+#include <linux/kobject.h>
+#include <linux/err.h>
+#include <linux/string.h>
+#include <linux/sysfs.h>
+#include <linux/list.h>
+#include <linux/slab.h>
+#include <asm-generic/bug.h>
+
+struct node
+{
+    struct list_head list;
+    const char *string;
+};
+
+struct my_object
+{
+    struct kobject  *kobj;
+    struct list_head strings_list;
+    struct kobj_attribute kattr;
+};
+
+static ssize_t string_show(struct kobject *kobj, struct kobj_attribute *attr,
+    char *buf);
+
+static ssize_t string_store(struct kobject *kobj, struct kobj_attribute *attr,
+    const char *buf, size_t count);
+
+static struct my_object string_storage =
+{
+    .kattr = __ATTR(list, 0660, string_show, string_store),
+};
+
+static ssize_t string_show(struct kobject *kobj, struct kobj_attribute *attr,
+    char *buf)
+{
+    struct node *entry;
+    struct list_head *entity;
+    struct list_head *tmp;
+    ssize_t len = 0;
+
+    (void)kobj;
+    (void)attr;
+
+    list_for_each_safe(entity, tmp, &string_storage.strings_list)
+    {
+        entry = list_entry(entity, struct node, list);
+
+        BUG_ON(entry == NULL);
+        BUG_ON(entry->string == NULL);
+
+        const size_t entry_len = strlen(entry->string);
+        const size_t tmp       = strlcpy(&buf[len], entry->string, PAGE_SIZE - len);
+        if (tmp != entry_len)
+        {
+            BUG();
+            len = -ENOMEM;
+            pr_err("[STR_STORAGE] String copy failed or PAGE_SIZE was reached");
+            break;
+        }
+
+        len += tmp;
+    }
+
+    if (len > 0)
+        pr_debug("[STR_STORAGE] String storage contains:\n%s", buf);
+
+    return len;
+}
+
+static ssize_t string_store(struct kobject *kobj, struct kobj_attribute *attr,
+    const char *buf, size_t count)
+{
+    struct node *str;
+
+    (void)kobj;
+    (void)attr;
+
+    str = kmalloc(sizeof(struct node), GFP_KERNEL);
+    if (str == NULL)
+        return -ENOMEM;
+
+    str->string = kstrdup_const(buf, GFP_KERNEL);
+    if (str->string == NULL)
+        return -ENOMEM;
+
+    pr_debug("[STR_STORAGE] String %s stored", str->string);
+
+    list_add_tail(&str->list, &string_storage.strings_list);
+
+    return count;
+}
+
+static int string_store_init(void)
+{
+    string_storage.kobj = kobject_create_and_add("string_storage", kernel_kobj);
+    if (string_storage.kobj == NULL)
+        return -ENOMEM;
+
+    const int res = sysfs_create_file(string_storage.kobj, &string_storage.kattr.attr);
+    if (res)
+    {
+        pr_err("[STR_STORAGE] Failed to create sysfs file");
+        kobject_put(string_storage.kobj);
+        return res;
+    }
+
+    INIT_LIST_HEAD(&string_storage.strings_list);
+
+    return res;
+}
+
+static void string_store_exit(void)
+{
+    struct node *entry;
+    struct list_head *entity;
+    struct list_head *tmp;
+
+    list_for_each_safe(entity, tmp, &string_storage.strings_list)
+    {
+        entry = list_entry(entity, struct node, list);
+
+        list_del(entity);
+
+        BUG_ON(entry == NULL);
+        BUG_ON(entry->string == NULL);
+
+        kfree(entry->string);
+        kfree(entry);
+    }
+
+    kobject_put(string_storage.kobj);
+    string_storage.kobj = NULL;
+}
+
+module_init(string_store_init);
+module_exit(string_store_exit);
+
+MODULE_DESCRIPTION("String Storage kernel module");
+MODULE_AUTHOR("Sergey D.");
+MODULE_LICENSE("GPL");

--- a/05_timers/timegetter/Makefile
+++ b/05_timers/timegetter/Makefile
@@ -1,0 +1,13 @@
+CC=gcc
+CC_FLAGS=-std=gnu11 -Wall
+
+CC_SOURCES=timegetter.c
+TARGET_NAME=timegetter
+
+$(TARGET_NAME):
+	$(CC) $(CC_FLAGS) -o $@ $(CC_SOURCES)
+
+all: clean $(TARGET_NAME)
+
+clean:
+	-$(RM) -rf *.o $(TARGET_NAME)

--- a/05_timers/timegetter/timegetter.c
+++ b/05_timers/timegetter/timegetter.c
@@ -1,0 +1,90 @@
+/**
+ * @file timegetter.c
+ * @brief User space program to get absolute time in seconds
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <linux/types.h>
+#include <unistd.h>
+#include <string.h>
+
+struct ClockGetter
+{
+    char option;
+    const char *name;
+    clockid_t clock_id;
+};
+
+#define MAX_CLOCK  (32u)
+
+static const struct ClockGetter clock_getter[] =
+{
+    { .option = 'r', .name = "CLOCK_REALTIME",           .clock_id = CLOCK_REALTIME           },
+    { .option = 'm', .name = "CLOCK_MONOTONIC",          .clock_id = CLOCK_MONOTONIC          },
+    { .option = 'p', .name = "CLOCK_PROCESS_CPUTIME_ID", .clock_id = CLOCK_PROCESS_CPUTIME_ID },
+    { .option = 't', .name = "CLOCK_THREAD_CPUTIME_ID",  .clock_id = CLOCK_THREAD_CPUTIME_ID  },
+};
+
+static const size_t clock_num = (sizeof(clock_getter) / sizeof(clock_getter[0]));
+
+/* MAX_CLOCK - 2 because we need to create an argument string with 'h' option an '\0' */
+_Static_assert((sizeof(clock_getter) / sizeof(clock_getter[0]) < MAX_CLOCK - 2), "Size error");
+
+int main(int argc, char* argv[])
+{
+    char *input_arg;
+    int c;
+    int i;
+    char args[MAX_CLOCK];
+
+    for (i = 0; i < clock_num; ++i)
+    {
+        args[i] = clock_getter[i].option;
+    }
+    /* Put help option h and \0 */
+    args[i]     = 'h';
+    args[i + 1] = '\0';
+
+    while ((c = getopt(argc, argv, args)) != -1)
+    {
+        if (c == 'h')
+        {
+            puts("Options:");
+            
+            for (int j = 0; j < clock_num; ++j)
+            {
+                printf("  -%c for %s\n", clock_getter[j].option, clock_getter[j].name);
+            }
+        }
+        else if ((input_arg = strchr(args, c)) != NULL)
+        {
+            int j = 0;
+            for (; j < clock_num; ++j)
+            {
+                if (clock_getter[j].option == *input_arg)
+                    break;
+            }
+            
+            struct timespec tp = { 0 };
+
+            if (clock_gettime(clock_getter[j].clock_id, &tp) != 0)
+                exit(EXIT_FAILURE);
+ 
+            printf("%s: %ld.%ld\n", clock_getter[j].name, tp.tv_sec, tp.tv_nsec);
+
+            if (clock_getres(clock_getter[j].clock_id, &tp) != 0)
+                exit(EXIT_FAILURE);
+
+            printf("Resolution of %s: %ld.%ld\n", clock_getter[j].name, tp.tv_sec, tp.tv_nsec);
+        }
+        else
+        {
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## 1. Timediff kernel module
This module uses ktime CLOCK_MONOTONIC to calculate relative and absolute time. It gives you relative time since last time_relative attribute read and gives you absolute time on each time_absolute reading.

## 2. Timegetter
This program allows you to get absolute time in seconds by different ways. Options:
```
-h to print available options
-r to read "CLOCK_REALTIME"
-m to read "CLOCK_MONOTONIC"
-p to read "CLOCK_PROCESS_CPUTIME_ID"
-t to read "CLOCK_THREAD_CPUTIME_ID"